### PR TITLE
Add support for firefly fanout

### DIFF
--- a/plugins/fireflyp/README.md
+++ b/plugins/fireflyp/README.md
@@ -169,12 +169,14 @@ Please refer to the Markdown-formatted documentation at the repository's root fo
 options. The following replicates the default configuration:
 
 ```yaml
-backends:
+plugins:
     firefly:
-        bindAddress: "127.0.01."
+        bindAddress: "127.0.0.1"
         bindPort: 10514
+        bufferSize: 4096
         deadline: 0
         hasSyslogHeader: false
+        fireflyReceivers: []
 ```
 
 <!-- REFs -->

--- a/plugins/fireflyp/conf.go
+++ b/plugins/fireflyp/conf.go
@@ -8,12 +8,21 @@ const (
 	minRecvBufferSize uint32 = 2048
 )
 
+// FireflyReceiver defines a single UDP destination to forward received fireflies to.
+type FireflyReceiver struct {
+	Address string `yaml:"address"`
+	Port    uint16 `yaml:"port"`
+}
+
 type Config struct {
 	BindAddress     string `yaml:"bindAddress"`
 	BindPort        uint16 `yaml:"bindPort"`
 	BufferSize      uint32 `yaml:"bufferSize"`
 	Deadline        uint32 `yaml:"deadline"`
 	HasSyslogHeader bool   `yaml:"hasSyslogHeader"`
+	// FireflyReceivers is an optional list of UDP destinations to relay
+	// received firefly datagrams to (e.g. an accounting receiver).
+	FireflyReceivers []FireflyReceiver `yaml:"fireflyReceivers"`
 }
 
 func (c *Config) UnmarshalYAML(b []byte) error {
@@ -21,11 +30,12 @@ func (c *Config) UnmarshalYAML(b []byte) error {
 	type config Config
 
 	def := &config{
-		BindAddress:     "127.0.0.1",
-		BindPort:        10514,
-		BufferSize:      2 * minRecvBufferSize,
-		Deadline:        0,
-		HasSyslogHeader: false,
+		BindAddress:      "127.0.0.1",
+		BindPort:         10514,
+		BufferSize:       2 * minRecvBufferSize,
+		Deadline:         0,
+		HasSyslogHeader:  false,
+		FireflyReceivers: []FireflyReceiver{},
 	}
 
 	if err := yaml.Unmarshal(b, def); err != nil {

--- a/plugins/fireflyp/firefly.go
+++ b/plugins/fireflyp/firefly.go
@@ -14,7 +14,8 @@ import (
 type FireflyPlugin struct {
 	Config
 
-	listener *net.UDPConn
+	listener   *net.UDPConn
+	forwarders []*net.UDPConn
 }
 
 func (p *FireflyPlugin) String() string {
@@ -44,6 +45,22 @@ func NewFireflyPlugin(c *Config) (*FireflyPlugin, error) {
 
 	p.listener = listener
 
+	// Set up outbound UDP connections for each firefly receiver.
+	for _, receiver := range p.FireflyReceivers {
+		dstAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", receiver.Address, receiver.Port))
+		if err != nil {
+			return nil, fmt.Errorf("error resolving firefly receiver %q:%d: %w", receiver.Address, receiver.Port, err)
+		}
+
+		conn, err := net.DialUDP("udp", nil, dstAddr)
+		if err != nil {
+			return nil, fmt.Errorf("error creating forwarder to firefly receiver %q:%d: %w", receiver.Address, receiver.Port, err)
+		}
+
+		slog.Debug("forwarding fireflies to receiver", "address", receiver.Address, "port", receiver.Port)
+		p.forwarders = append(p.forwarders, conn)
+	}
+
 	return &p, nil
 }
 
@@ -72,26 +89,47 @@ func (p *FireflyPlugin) Run(done <-chan struct{}, outChan chan<- glowdTypes.Flow
 				slog.Error("error reading from UDP", "err", err)
 				continue
 			}
-			slog.Debug("read from UDP", "n", n, "from", *addr)
+			slog.Debug("read raw firefly", "n", n, "from", *addr)
 
-			go func(msg []byte) {
+			rawFirefly := recvBuffer[:n]
+
+			// Forward the raw datagram to all configured firefly receivers.
+			for _, fwd := range p.forwarders {
+				go func(conn *net.UDPConn, data []byte) {
+					slog.Debug("forwarding firefly to receiver", "dst", conn.RemoteAddr())
+
+					if _, err := conn.Write(data); err != nil {
+						slog.Error("error forwarding firefly to receiver", "dst", conn.RemoteAddr(), "err", err)
+					}
+				}(fwd, rawFirefly)
+			}
+
+			// Extract the FlowID from the incoming firefly
+			go func(raw []byte) {
 				slog.Debug("serving an incoming UDP firefly")
 
 				auxFirefly := glowdTypes.SlimFirefly{}
-				if err := auxFirefly.Parse(msg); err != nil {
+				if err := auxFirefly.Parse(raw); err != nil {
 					slog.Error("couldn't parse the incoming firefly", "err", err,
 						"hasSyslogHeader", p.HasSyslogHeader)
 				}
 
 				outChan <- auxFirefly.FlowID
-
-			}(recvBuffer[:n])
+			}(rawFirefly)
 		}
 	}
 }
 
 func (p *FireflyPlugin) Cleanup() error {
 	slog.Debug("cleaning up the firefly plugin")
+
+	// Close all firefly receiver connections.
+	for _, fwd := range p.forwarders {
+		if err := fwd.Close(); err != nil {
+			slog.Error("error closing firefly forwarder connection", "dst", fwd.RemoteAddr(), "err", err)
+		}
+	}
+
 	if err := p.listener.Close(); err != nil {
 		slog.Error("error closing the UDP listener", "err", err)
 	}

--- a/rpm/conf.yaml
+++ b/rpm/conf.yaml
@@ -49,6 +49,10 @@
     #     # for parsing the embedded JSON payload.
     #     hasSyslogHeader: false
 
+    #     # Optionally forward received fireflies verbatim to one or more UDP
+    #     # destinations before parsing. Each entry needs an address and a port.
+    #     fireflyReceivers: []
+
     # # Detect TCP connections based on source and destination ports
     # iperf3:
     #     # Lower bound (inclusive) of the source port range. If 0, this check

--- a/rpm/flowd-go.1.md
+++ b/rpm/flowd-go.1.md
@@ -134,6 +134,12 @@ relay. Be sure to check the documentation on the firelfy backend for more inform
 
 - **hasSyslogHeader [bool] {false}**: Whether the incoming fireflies contain the syslog header or not.
 
+- **fireflyReceivers [array of objects] {[]}**: A list of UDP destinations to which received firefly
+  datagrams are forwarded verbatim before parsing. Each entry is an object with the following fields:
+
+    - **address [string]**: The hostname or IP address of the destination.
+    - **port [int]**: The UDP port of the destination. Must be equal to or lower than `65535`.
+
 ## perfsonar
 The **perfSONAR** plugin will simply mark **all outgoing traffic** with the provided activity and experiment IDs. If the `matchAll` option of
 the `marker` backend is not set to `true`, this plugin will overwrite the setting, emitting a warning in the process. This plugin is devised

--- a/rpm/flowd-go.1.md
+++ b/rpm/flowd-go.1.md
@@ -430,4 +430,4 @@ its default value is enclosed in braces (`{}`).
 # AUTHORS
 - Tristan Sullivan (CERN)
 - Marian Babik (CERN)
-- Pablo Collado Soto <pablo.collado@uam.es> (Universidad Autónoma de Madrid)
+- Pablo Collado Soto <pablo.collado.soto@cern.ch> (CERN)


### PR DESCRIPTION
Add an option to forward incoming fireflies verbatim to an arbitrary set of receivers. This functionality is required when leveraging `flowd-go` on `perfSONAR` deployments.

Please note this PR is based on the changes proposed by @ShawnMcKee on #49 and #50. This PR simply merges the proposed set of changes and trims the log so as not to bloat it.